### PR TITLE
Use legacy noarch declaration to support conda version prior to 4.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,11 +10,11 @@ source:
   git_rev: {{ version }}
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
   entry_points:
     - conda-devenv = conda_devenv.devenv:main
-  noarch: python
+  noarch_python: True
 
 requirements:
   build:


### PR DESCRIPTION
See: https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#architecture-independent-packages

This sounds reasonable for you?
I have been seeing "Installing mirror-conda-forge::conda-devenv-1.0.0-py_0 requires a minimum conda version of 4.3." a lot since 1.0.0 with noarch has been released because some times there is a older conda version installed on root.