### PR TITLE
Change the recipe to use tarballs

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,11 +6,12 @@ package:
   version: {{ version }}
 
 source:
-  git_url: https://github.com/ESSS/{{ name }}.git
-  git_rev: {{ version }}
+  fn: {{ name }}-{{ version }}.zip
+  url: https://github.com/ESSS/{{ name }}/archive/{{ version }}.zip
+  sha256: 9e7b8187cfabe8c369ad1b73aac0f8da947b8c9655ba65617502e3dbbc7093c6
 
 build:
-  number: 1
+  number: 2
   script: python -m pip install . --no-deps --ignore-installed
   entry_points:
     - conda-devenv = conda_devenv.devenv:main


### PR DESCRIPTION
The recommendation in conda is to use tarballs instead of git to download the source code.